### PR TITLE
Fix old gem version for ruby 3

### DIFF
--- a/lib/file_validators/validators/file_content_type_validator.rb
+++ b/lib/file_validators/validators/file_content_type_validator.rb
@@ -99,7 +99,7 @@ module ActiveModel
       def mark_invalid(record, attribute, error, option_types)
         error_options = options.merge(types: option_types.join(', '))
         unless record.errors.added?(attribute, error, error_options)
-          record.errors.add attribute, error, error_options
+          record.errors.add attribute, error, **error_options
         end
       end
     end

--- a/lib/file_validators/validators/file_size_validator.rb
+++ b/lib/file_validators/validators/file_size_validator.rb
@@ -20,7 +20,7 @@ module ActiveModel
             if values.any? { |v| not valid_size?(value_byte_size(v), option, option_value) }
               record.errors.add(attribute,
                                 "file_size_is_#{option}".to_sym,
-                                filtered_options(values).merge!(detect_error_options(option_value)))
+                                **filtered_options(values).merge!(detect_error_options(option_value)))
             end
           end
         end


### PR DESCRIPTION
This branch is based on an old commit from the upstream repo before 3.0.0 of the gem was released. It therefore doesn't include the `mime_type_analyzer`, which doesn't work with `Carrierwave` as far as I can tell.

[This line](https://github.com/musaffa/file_validators/blob/master/lib/file_validators/mime_type_analyzer.rb#L27) in particular errors, because the Carrierwave uploader doesn't have `eof?` method. The old implementation of the content type checker does still work with Carrierwave.

However, the old `file_validators` version isn't compatible with Ruby 3. This branch therefore also includes the changes from [this commit](https://github.com/musaffa/file_validators/commit/d13cc40e861336f05a3718caa94df7f63794578e).